### PR TITLE
Check for _id attr in __cmp__ methods

### DIFF
--- a/octgnFX/Octgn/Scripting/PythonAPI.py
+++ b/octgnFX/Octgn/Scripting/PythonAPI.py
@@ -164,6 +164,7 @@ class Card(object):
     self._markers = None
   def __cmp__(self, other):
     if other == None: return 1
+    elif not hasattr(other, "_id"): return 1
     return cmp(self._id, other._id)
   def __hash__(self):
     return self._id
@@ -258,6 +259,7 @@ class NamedObject(object):
     self._name = name
   def __cmp__(self, other):
     if other == None: return 1
+    elif not hasattr(other, "_id"): return 1
     return cmp(self._id, other._id)
   def __hash__(self):
     return self._id
@@ -354,6 +356,7 @@ class Player(object):
     self._piles = idict((pair.Value, Pile(pair.Key, pair.Value, self)) for pair in _api.PlayerPiles(id))
   def __cmp__(self, other):
     if other == None: return 1
+    elif not hasattr(other, "_id"): return 1
     return cmp(self._id, other._id)
   def __hash__(self):
     return self._id


### PR DESCRIPTION
To simplify comparison of Card, NamedObject, and Player objects with non-OCTGN (such as "some_variable == some_card"), check that the other object actually has an ._id attribute. Otherwise, an exception is thrown, thus requiring more of verbosity higher up to avoid this.