### PR TITLE
Readability for the amount of cards left in a filter for the PickCardsDialog

### DIFF
--- a/octgnFX/Octgn/Play/Dialogs/PickCardsDialog.xaml
+++ b/octgnFX/Octgn/Play/Dialogs/PickCardsDialog.xaml
@@ -95,7 +95,7 @@ Template="{StaticResource ExpanderButton}" />
                           Checked="FilterChecked" Unchecked="FilterUnchecked">
                                     <TextBlock Text="{Binding Value, Mode=OneTime}" VerticalAlignment="Center" />
                                 </CheckBox>
-                                <TextBlock Text="{Binding Count}" HorizontalAlignment="Right" Foreground="#999999"
+                                <TextBlock Text="{Binding Count}" HorizontalAlignment="Right" Foreground="#000000"
                            VerticalAlignment="Center" />
                             </Grid>
                         </DataTemplate>


### PR DESCRIPTION
I have a friend I play OCTGN with , that has poor eyesight.  He was complaining to me during a limited game , that he couldn't read the amount of cards available in a filter.

I wanted to learn about the OCTGN codebase, so I forked and gave it a shot.  I found the property holding the color in the TextTemplate tag of the xaml and altered it to pure black.  I send the exe over to my friend, he tried it and was happy.  So I figured this might help others as well and is worth a pull request.