### PR TITLE
Enabled the nicer font rendering mode in all windows.

### DIFF
--- a/octgnFX/Octgn/Windows/AboutWindow.xaml
+++ b/octgnFX/Octgn/Windows/AboutWindow.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:Controls="clr-namespace:Octgn.Controls"
         xmlns:octgn="clr-namespace:Octgn"
+        TextOptions.TextFormattingMode="Display"
         Title="About The Dev Team" CanResize="False" MinMaxButtonVisibility="Hidden"
         WindowIcon="pack://application:,,,/OCTGN;component/Resources/Icons/About.png" SizeToContent="WidthAndHeight"
         Width="596" Height="325">

--- a/octgnFX/Octgn/Windows/BrowserWindow.xaml
+++ b/octgnFX/Octgn/Windows/BrowserWindow.xaml
@@ -1,6 +1,7 @@
 ﻿<Window x:Class="Octgn.Windows.BrowserWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        TextOptions.TextFormattingMode="Display"
         Title="BrowserWindow" Height="610" Width="900"
         x:Name="Me" DataContext="{Binding ElementName=Me}">
     <Grid>

--- a/octgnFX/Octgn/Windows/ChatWindow.xaml
+++ b/octgnFX/Octgn/Windows/ChatWindow.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
         xmlns:controls="clr-namespace:Octgn.Controls"
+        TextOptions.TextFormattingMode="Display"
         Title="ChatWindow" Height="300" Width="600"
         WindowIcon="pack://application:,,,/OCTGN;component/Resources/chat.ico"
         MinWidth="600" MinHeight="300">

--- a/octgnFX/Octgn/Windows/DWindow.xaml
+++ b/octgnFX/Octgn/Windows/DWindow.xaml
@@ -1,5 +1,6 @@
 <Window x:Class="Octgn.Windows.DWindow" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Title="DebugWindow" Height="244" Width="460"
+        TextOptions.TextFormattingMode="Display"
         IsVisibleChanged="WindowIsVisibleChanged" Closing="WindowClosing">
   <Grid>
     <RichTextBox x:Name="output" IsReadOnly="True" ScrollViewer.VerticalScrollBarVisibility="Visible"

--- a/octgnFX/Octgn/Windows/Diagnostics.xaml
+++ b/octgnFX/Octgn/Windows/Diagnostics.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:library="clr-namespace:Octgn.Library;assembly=Octgn.Library"
+        TextOptions.TextFormattingMode="Display"
         Title="Diagnostics" MinWidth="846" Width="846"
         SizeToContent="Height"
         x:Name="Me" DataContext="{Binding ElementName=Me}" Icon="/OCTGN;component/Resources/Icons/diag.ico">

--- a/octgnFX/Octgn/Windows/ErrorWindow.xaml
+++ b/octgnFX/Octgn/Windows/ErrorWindow.xaml
@@ -1,5 +1,6 @@
 <Window x:Class="Octgn.Windows.ErrorWindow" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Title="Error" Height="414" Width="622"
+        TextOptions.TextFormattingMode="Display"
         Style="{StaticResource Window}">
 
   <Grid>

--- a/octgnFX/Octgn/Windows/GameLog.xaml
+++ b/octgnFX/Octgn/Windows/GameLog.xaml
@@ -1,6 +1,7 @@
 ﻿<Window x:Class="Octgn.Windows.GameLog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:gui="clr-namespace:Octgn.Play.Gui"
+        TextOptions.TextFormattingMode="Display"
         Title="Full Game Log" Height="409" Width="643" Icon="pack://application:,,,/OCTGN;component/Resources/log2.ico"
         Background="#333333" Visibility="Hidden">
     <Grid>

--- a/octgnFX/Octgn/Windows/GrowlNotifications.xaml
+++ b/octgnFX/Octgn/Windows/GrowlNotifications.xaml
@@ -7,6 +7,7 @@
         mc:Ignorable="d"
 		BorderThickness="0"
         ResizeMode="NoResize"
+        TextOptions.TextFormattingMode="Display"
         Title="GrowlNotifiactions" Width="300" ShowActivated="False" AllowsTransparency="true" WindowStyle="None" ShowInTaskbar="False" Background="Transparent" Topmost="True" UseLayoutRounding="True">
     <Window.Resources>
         <Storyboard x:Key="CollapseStoryboard">

--- a/octgnFX/Octgn/Windows/Main.xaml
+++ b/octgnFX/Octgn/Windows/Main.xaml
@@ -7,6 +7,7 @@
     xmlns:deckBuilder="clr-namespace:Octgn.DeckBuilder"
     xmlns:matchmaking="clr-namespace:Octgn.Tabs.Matchmaking"
     xmlns:challengeBoards="clr-namespace:Octgn.Tabs.ChallengeBoards"
+    TextOptions.TextFormattingMode="Display"
     x:Class="Octgn.Windows.Main"
         Title="OCTGN"
     x:Name="me"

--- a/octgnFX/Octgn/Windows/Options.xaml
+++ b/octgnFX/Octgn/Windows/Options.xaml
@@ -3,6 +3,7 @@
         xmlns:controls="clr-namespace:Octgn.Controls" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:Gui="clr-namespace:Octgn.Play.Gui" 
         mc:Ignorable="d" x:Class="Octgn.Windows.Options"
+        TextOptions.TextFormattingMode="Display"
         Title="OCTGN Options" WindowIcon="/OCTGN;component/Resources/Icons/setting_tools.png" 
         VerticalContentAlignment="Stretch" HorizontalContentAlignment="Stretch" SizeToContent="Height" VerticalAlignment="Top"
         WindowStartupLocation="CenterOwner" Width="537.424" d:DesignHeight="452" >

--- a/octgnFX/Octgn/Windows/PickCardFromList.xaml
+++ b/octgnFX/Octgn/Windows/PickCardFromList.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:windows="clr-namespace:Octgn.Windows"
+        TextOptions.TextFormattingMode="Display"
         Title="Pick A Card" MinHeight="420" MinWidth="680" 
         Height="420" Width="680"
         x:Name="Me" DataContext="{Binding ElementName=Me}">

--- a/octgnFX/Octgn/Windows/ShareDeck.xaml
+++ b/octgnFX/Octgn/Windows/ShareDeck.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:Octgn.Controls"
+        TextOptions.TextFormattingMode="Display"
         CanResize="False" CloseButtonVisibility="Collapsed" MinMaxButtonVisibility="Collapsed" 
         MinimizeButtonVisibility="Collapsed" WindowIcon="pack://application:,,,/OCTGN;component/Resources/FileIcons/Deck.ico"
         SizeToContent="Height"

--- a/octgnFX/Octgn/Windows/UpdateChecker.xaml
+++ b/octgnFX/Octgn/Windows/UpdateChecker.xaml
@@ -2,6 +2,7 @@
         x:Class="Octgn.Windows.UpdateChecker" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
         xmlns:Controls="clr-namespace:Octgn.Controls"
+        TextOptions.TextFormattingMode="Display"
         Title="Loading Octgn..." MinHeight="237" MinWidth="438" Height="Auto" Width="500"
         WindowStartupLocation="CenterScreen" WindowIcon="/OCTGN;component/Resources/Icons/Reset.png" 
         ResizeMode="CanResizeWithGrip" ShowInTaskbar="True" Topmost="False" 

--- a/octgnFX/Octgn/Windows/UpgradeMessage.xaml
+++ b/octgnFX/Octgn/Windows/UpgradeMessage.xaml
@@ -1,5 +1,6 @@
 <Window x:Class="Octgn.Windows.UpgradeMessage" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Title="Octgn - Upgrade" Style="{StaticResource Window}"
+        TextOptions.TextFormattingMode="Display"
         Width="451" ResizeMode="NoResize" SizeToContent="Height" WindowStartupLocation="CenterScreen">
     <Border Style="{StaticResource Panel}" Margin="8" Padding="8">
     <Grid>

--- a/octgnFX/Octgn/Windows/UserProfileWindow.xaml
+++ b/octgnFX/Octgn/Windows/UserProfileWindow.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:profile="clr-namespace:Octgn.Tabs.Profile"
         xmlns:controls="clr-namespace:Octgn.Controls"
+        TextOptions.TextFormattingMode="Display"
         Height="600" Width="800"
         MinMaxButtonVisibility="Collapsed"
         x:Name="Me"


### PR DESCRIPTION
Enable the better-looking "Display" font rendering mode in all windows. Before and after screenshots: http://i.imgur.com/BgrIhyF.png

Two files have line ending changes, presumably due to .gitattribute. I'm not sure if there's a way around that.