### PR TITLE
Visual polish:

### DIFF
--- a/octgnFX/Octgn/Controls/CustomGames.xaml
+++ b/octgnFX/Octgn/Controls/CustomGames.xaml
@@ -56,10 +56,10 @@
                 <!--<Button Click="ButtonRefreshClick" Width="35" Height="30" Margin="0,0,5,0" FontSize="35" Padding="0 -6 0 0"
                         Style="{StaticResource FlatDarkOrangeButtonStyle}" x:Name="ButtonRefresh"
                         FontFamily="{StaticResource Entypo}" ToolTip="Refresh Game List">&#10227;</Button>-->
-                <Button Click="ButtonHostClick" Content="Start" Width="80" Height="30" Margin="0,0,5,0" Style="{StaticResource FlatDarkGreenButtonStyle}"></Button>
-                <Button Click="ButtonJoinClick" Content="Join" Width="80" Height="30" Margin="0,0,5,0" Style="{StaticResource FlatDarkButtonStyle}"
+                <Button Click="ButtonHostClick" Content="Start" MinWidth="80" Height="30" Margin="0,0,5,0" Style="{StaticResource FlatDarkGreenButtonStyle}"></Button>
+                <Button Click="ButtonJoinClick" Content="Join" MinWidth="80" Height="30" Margin="0,0,5,0" Style="{StaticResource FlatDarkButtonStyle}"
                         IsEnabled="{Binding IsJoinableGameSelected, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:CustomGameList}}}"/>
-                <Button Click="ButtonJoinOfflineGame" Content="Join Unlisted" Width="80" 
+                <Button Click="ButtonJoinOfflineGame" Content="Join Unlisted" MinWidth="80" Padding="5,0"
                         Height="30" Margin="0,0,0,0" Style="{StaticResource FlatDarkButtonStyle}"></Button>
                 <toggleSwitch:HorizontalToggleSwitch Width="220" IsChecked="{Binding ElementName=Me,Path=ShowUninstalledGames, Mode=TwoWay,NotifyOnSourceUpdated=True, NotifyOnTargetUpdated=True}">
                     <toggleSwitch:HorizontalToggleSwitch.CheckedContent>
@@ -78,7 +78,7 @@
                     </toggleSwitch:HorizontalToggleSwitch.UncheckedContent>
                 </toggleSwitch:HorizontalToggleSwitch>
                 <Grid Width="6"></Grid>
-                <Button Click="ButtonKillGame" Content="Kill Game" Width="80" 
+                <Button Click="ButtonKillGame" Content="Kill Game" MinWidth="80" Padding="5,0"
                         Height="30" Margin="0,0,0,0" Style="{StaticResource FlatDarkRedButtonStyle}"
                         Visibility="{Binding ElementName=Me,Path=ShowKillGameButton,Converter={StaticResource BooleanToVisibilityConverter}}"
                         />

--- a/octgnFX/Octgn/Controls/FeatureFundingMessage.xaml
+++ b/octgnFX/Octgn/Controls/FeatureFundingMessage.xaml
@@ -118,10 +118,10 @@
                     <ColumnDefinition Width="100*"/>
                     <ColumnDefinition Width="150"/>
                     <ColumnDefinition Width="5"/>
-                    <ColumnDefinition Width="150"/>
+                    <ColumnDefinition Width="auto"/>
                 </Grid.ColumnDefinitions>
                 <!--<Button Content="Subscription Benefits" Height="35" Click="BenefitsClick" Grid.Column="1" Style="{StaticResource FlatDarkRedButtonStyle}"/>-->
-                <Button Content="Subscribe(More Info)" Height="35" Click="SubscribeClick" Grid.Column="3" x:Name="SubButton" Style="{StaticResource FlatDarkGreenButtonStyle}"></Button>
+                <Button Content="Subscribe (More Info)" Height="35" Padding="10,0" Click="SubscribeClick" Grid.Column="3" x:Name="SubButton" Style="{StaticResource FlatDarkGreenButtonStyle}"></Button>
             </Grid>
         </StackPanel>
     </Grid>

--- a/octgnFX/Octgn/Tabs/GameManagement/GameManagement.xaml
+++ b/octgnFX/Octgn/Tabs/GameManagement/GameManagement.xaml
@@ -34,10 +34,10 @@
                         </DataTemplate>
                     </ComboBox.ItemTemplate>
                 </ComboBox>
-                <Button Click="ButtonAddClick" Content="Add Game Feed" Width="130" Height="30" VerticalAlignment="Center" Margin="0,0,5,0" Style="{StaticResource FlatDarkGreenButtonStyle}"></Button>
-                <Button IsEnabled="{Binding RemoveButtonEnabled}" Click="ButtonRemoveClick" Content="Remove Game Feed" Width="120" Height="30" VerticalAlignment="Center" Margin="0,0,5,0" Style="{StaticResource FlatDarkButtonStyle}"></Button>
+                <Button Click="ButtonAddClick" Content="Add Game Feed" Padding="6,0" Height="30" VerticalAlignment="Center" Margin="0,0,5,0" Style="{StaticResource FlatDarkGreenButtonStyle}"></Button>
+                <Button IsEnabled="{Binding RemoveButtonEnabled}" Click="ButtonRemoveClick" Content="Remove Game Feed" Padding="6,0" Height="30" VerticalAlignment="Center" Margin="0,0,5,0" Style="{StaticResource FlatDarkButtonStyle}"></Button>
                 <!--<Button Click="ButtonAddo8gClick" Content="Add o8g" Width="60" Height="30" VerticalAlignment="Center" Margin="0,0,5,0"></Button>-->
-                <Button Click="ButtonAddo8cClick" Content="Add Image Packs" Width="120" Height="30" VerticalAlignment="Center" Margin="0,0,5,0" Style="{StaticResource FlatDarkButtonStyle}"></Button>
+                <Button Click="ButtonAddo8cClick" Content="Add Image Packs" Padding="6,0" Height="30" VerticalAlignment="Center" Margin="0,0,5,0" Style="{StaticResource FlatDarkButtonStyle}"></Button>
             </WrapPanel>
         </Border>
         <ListBox x:Name="ListBoxGames" Grid.Column="1" Grid.Row="2" Background="Transparent" ItemsSource="{Binding Packages}" SelectedItem="{Binding SelectedGame,Mode=TwoWay}" HorizontalContentAlignment="Stretch" HorizontalAlignment="Stretch">

--- a/octgnFX/Octgn/Tabs/Login/LoginNew.xaml
+++ b/octgnFX/Octgn/Tabs/Login/LoginNew.xaml
@@ -26,18 +26,18 @@
                     </RadialGradientBrush>
                 </Line.Stroke>
             </Line>
-            <Border BorderBrush="Silver" BorderThickness="0" Height="32" HorizontalAlignment="Stretch" Margin="10,7,0,0"
+            <Border BorderBrush="Silver" BorderThickness="0" Height="32" HorizontalAlignment="Stretch" Margin="10,7,10,0"
               Name="border2" Style="{StaticResource DarkPanel}" VerticalAlignment="Top" Visibility="Visible" Grid.Row="2" CornerRadius="0">
                 <TextBlock FontWeight="Bold" Foreground="White" HorizontalAlignment="Center" Name="textBlock1"
                    Text="Sign In / Register" VerticalAlignment="Stretch" FontSize="20" />
             </Border>
             <StackPanel x:Name="spleft" Grid.Row="3" MinWidth="300" Margin="10,0">
                 <Label Content="Username (no e-mails)" HorizontalAlignment="Left" Name="label1" VerticalAlignment="Top"
-                    Foreground="White" FontWeight="Bold" FontSize="14" Margin="0,6,0,4" />
+                    Foreground="White" FontWeight="Bold" FontSize="14" Margin="4,6,0,4" />
                 <TextBox HorizontalAlignment="Stretch" Name="textBox1" VerticalAlignment="Top"
                     TextChanged="TextBox1TextChanged" KeyUp="TextBox1KeyUp" />
                 <Label Content="Password" FontSize="14" FontWeight="Bold" Foreground="White"
-        	        HorizontalAlignment="Left" x:Name="label2" VerticalAlignment="Top" Margin="0,6,0,4" />
+        	        HorizontalAlignment="Left" x:Name="label2" VerticalAlignment="Top" Margin="4,6,0,4" />
                 <PasswordBox Name="passwordBox1" VerticalAlignment="Top" HorizontalAlignment="Stretch"
                      PasswordChanged="PasswordBox1PasswordChanged" KeyUp="PasswordBox1KeyUp" />
                 <Label Content="Email" FontSize="14" FontWeight="Bold" Foreground="White" Height="28"
@@ -69,14 +69,14 @@
                 </Grid>
             </StackPanel>
 
-            <StackPanel Grid.Row="2" Grid.Column="1" Margin="20 0 0 0">
+            <StackPanel Grid.Row="2" Grid.Column="1" Margin="25,0,10,0">
                 <!-- http://stats.pingdom.com/qrzmgw5y7owr -->
                 <TextBlock Text="OCTGN Server Status" Foreground="White" Cursor="Hand" FontWeight="Bold" MouseUp="ServerStatusLinkClick"/>
-                <TextBlock Text="Twitter @Octgn_Official (Can find server status updates here)" Foreground="White" Cursor="Hand" FontWeight="Bold" TextWrapping="Wrap" MouseUp="TwitterLinkClick"/>
+                <TextBlock Text="Twitter @Octgn_Official (server status updates are here)" Foreground="White" Cursor="Hand" FontWeight="Bold" TextWrapping="Wrap" MouseUp="TwitterLinkClick"/>
             </StackPanel>
 
-            <Border BorderThickness="1"  HorizontalAlignment="Center" Margin="18,10,10,0" Name="border3"
-            Style="{StaticResource DarkPanel}" VerticalAlignment="Stretch" Visibility="Visible" Width="347" Grid.Row="3" Grid.Column="1"
+            <Border BorderThickness="1"  HorizontalAlignment="Stretch" Margin="25,10,10,10" Name="border3" MaxWidth="500"
+            Style="{StaticResource DarkPanel}" VerticalAlignment="Stretch" Visibility="Visible" Grid.Row="3" Grid.Column="1"
             Padding="5" Grid.RowSpan="1">
                 <ScrollViewer VerticalScrollBarVisibility="Auto" ClipToBounds="True">
                     <TextBlock FontWeight="Bold" Foreground="White" HorizontalAlignment="Center" Name="textBlock5"

--- a/octgnFX/Octgn/Tabs/Login/LoginNew.xaml
+++ b/octgnFX/Octgn/Tabs/Login/LoginNew.xaml
@@ -16,7 +16,7 @@
                 <RowDefinition Height="44" />
                 <RowDefinition Height="100*" />
             </Grid.RowDefinitions>
-            <Line Grid.Row="2" StrokeThickness="4" HorizontalAlignment="Center" X1="1" X2="1" Y1="1" Y2="217" Margin="8,0,363,0" Grid.RowSpan="2" Width="4" Grid.Column="1">
+            <Line Grid.Row="2" StrokeThickness="4" HorizontalAlignment="Left" VerticalAlignment="Center" X1="1" X2="1" Y1="1" Y2="330" Margin="8,0,0,0" Grid.RowSpan="2" Width="4" Grid.Column="1">
                 <Line.Stroke>
                     <RadialGradientBrush GradientOrigin="0.5,0.5" Center="0.5,0.5" RadiusX="0.5" RadiusY="0.5">
                         <RadialGradientBrush.GradientStops>
@@ -29,23 +29,23 @@
             <Border BorderBrush="Silver" BorderThickness="0" Height="32" HorizontalAlignment="Stretch" Margin="10,7,0,0"
               Name="border2" Style="{StaticResource DarkPanel}" VerticalAlignment="Top" Visibility="Visible" Grid.Row="2" CornerRadius="0">
                 <TextBlock FontWeight="Bold" Foreground="White" HorizontalAlignment="Center" Name="textBlock1"
-                   Text="Signin/Register" VerticalAlignment="Stretch" FontSize="20" />
+                   Text="Sign In / Register" VerticalAlignment="Stretch" FontSize="20" />
             </Border>
-            <StackPanel x:Name="spleft" Grid.Row="3" MinWidth="300">
-                <Label Content="Username(no e-mails)" Height="26" HorizontalAlignment="Left" Name="label1" VerticalAlignment="Top"
-                    Width="223" Foreground="White" FontWeight="Bold" FontSize="14" Margin="10,0" />
-                <TextBox Height="23" HorizontalAlignment="Stretch" Name="textBox1" VerticalAlignment="Top"
-                    TextChanged="TextBox1TextChanged" Margin="10,0" KeyUp="TextBox1KeyUp" />
-                <Label Content="Password" FontSize="14" FontWeight="Bold" Foreground="White" Height="28"
-        	        HorizontalAlignment="Left" x:Name="label2" VerticalAlignment="Top" Width="119" Margin="10,0,0,0" />
-                <PasswordBox Height="23" Name="passwordBox1" VerticalAlignment="Top" HorizontalAlignment="Stretch"
-                     PasswordChanged="PasswordBox1PasswordChanged" Margin="10,0" KeyUp="PasswordBox1KeyUp" />
+            <StackPanel x:Name="spleft" Grid.Row="3" MinWidth="300" Margin="10,0">
+                <Label Content="Username (no e-mails)" HorizontalAlignment="Left" Name="label1" VerticalAlignment="Top"
+                    Foreground="White" FontWeight="Bold" FontSize="14" Margin="0,6,0,4" />
+                <TextBox HorizontalAlignment="Stretch" Name="textBox1" VerticalAlignment="Top"
+                    TextChanged="TextBox1TextChanged" KeyUp="TextBox1KeyUp" />
+                <Label Content="Password" FontSize="14" FontWeight="Bold" Foreground="White"
+        	        HorizontalAlignment="Left" x:Name="label2" VerticalAlignment="Top" Margin="0,6,0,4" />
+                <PasswordBox Name="passwordBox1" VerticalAlignment="Top" HorizontalAlignment="Stretch"
+                     PasswordChanged="PasswordBox1PasswordChanged" KeyUp="PasswordBox1KeyUp" />
                 <Label Content="Email" FontSize="14" FontWeight="Bold" Foreground="White" Height="28"
                     HorizontalAlignment="Left" Name="labelEmail" VerticalAlignment="Top" Width="119" Grid.Row="2" Margin="10,0" Visibility="Collapsed"/>
                 <TextBox Height="23" HorizontalAlignment="Stretch" Name="textBoxEmail" VerticalAlignment="Top"
                     TextChanged="TextBox1TextChanged" Margin="10,0" KeyUp="TextBox1KeyUp" Visibility="Collapsed"/>
                 <Grid>
-                    <Button Content="Sign In" Height="37" Name="button1" Width="125" Click="Button1Click" Margin="0,10,10,10"
+                    <Button Content="Sign In" Height="37" Name="button1" Width="125" Click="Button1Click" Margin="0,15"
                         HorizontalAlignment="Right" IsEnabled="True" RenderTransformOrigin="1.767,0.405" Style="{StaticResource FlatDarkGreenButtonStyle}"/>
                 </Grid>
                 <Label x:Name="labelRegister" HorizontalAlignment="Right" Foreground="White" Cursor="Hand">Register</Label>
@@ -75,7 +75,7 @@
                 <TextBlock Text="Twitter @Octgn_Official (Can find server status updates here)" Foreground="White" Cursor="Hand" FontWeight="Bold" TextWrapping="Wrap" MouseUp="TwitterLinkClick"/>
             </StackPanel>
 
-            <Border BorderThickness="1"  HorizontalAlignment="Center" Margin="18,0,10,0" Name="border3"
+            <Border BorderThickness="1"  HorizontalAlignment="Center" Margin="18,10,10,0" Name="border3"
             Style="{StaticResource DarkPanel}" VerticalAlignment="Stretch" Visibility="Visible" Width="347" Grid.Row="3" Grid.Column="1"
             Padding="5" Grid.RowSpan="1">
                 <ScrollViewer VerticalScrollBarVisibility="Auto" ClipToBounds="True">

--- a/octgnFX/Octgn/Tabs/Login/LoginNew.xaml.cs
+++ b/octgnFX/Octgn/Tabs/Login/LoginNew.xaml.cs
@@ -356,8 +356,8 @@ namespace Octgn.Tabs.Login
 
         #region UI Events
         private void Button1Click(object sender, RoutedEventArgs e) { DoLogin(); }
-        private void TextBox1TextChanged(object sender, TextChangedEventArgs e) { bError.Visibility = Visibility.Hidden; }
-        private void PasswordBox1PasswordChanged(object sender, RoutedEventArgs e) { bError.Visibility = Visibility.Hidden; }
+        private void TextBox1TextChanged(object sender, TextChangedEventArgs e) { bError.Visibility = Visibility.Collapsed; }
+        private void PasswordBox1PasswordChanged(object sender, RoutedEventArgs e) { bError.Visibility = Visibility.Collapsed; }
 
         private void TextBox1KeyUp(object sender, KeyEventArgs e)
         {

--- a/octgnFX/Octgn/Windows/Main.xaml
+++ b/octgnFX/Octgn/Windows/Main.xaml
@@ -32,15 +32,15 @@
         <Controls:SubscribeMessage x:Name="SubMessage" Grid.RowSpan="10" Grid.ColumnSpan="10" Visibility="Collapsed" Canvas.ZIndex="10"></Controls:SubscribeMessage>
         <Menu Grid.ColumnSpan="4" Grid.Row="0">
             <MenuItem Header="_File">
-                <!--<MenuItem x:Name="menuLogOff" Header="_Log Off" HorizontalAlignment="Left" Width="137" Click="MenuLogOffClick"/>-->
-                <MenuItem x:Name="menuExit" Header="E_xit" HorizontalAlignment="Left" Width="137" Click="MenuExitClick"/>
+                <!--<MenuItem x:Name="menuLogOff" Header="_Log Off" HorizontalAlignment="Left" MinWidth="137" Click="MenuLogOffClick"/>-->
+                <MenuItem x:Name="menuExit" Header="E_xit" HorizontalAlignment="Left" MinWidth="137" Click="MenuExitClick"/>
             </MenuItem>
             <MenuItem x:Name="menuOptions" Header="_Options" Click="MenuOptionsClick">
             </MenuItem>
             <MenuItem Header="_Deck Editor" Click="MenuDeckEditorClick"></MenuItem>
             <MenuItem Header="_Help">
-                <MenuItem x:Name="menuHelp" Header="Get _Help Online" HorizontalAlignment="Left" Width="137" Click="MenuHelpClick"/>
-                <MenuItem x:Name="menuDiag" Header="_Diagnostics" HorizontalAlignment="Left" Width="137" Click="MenuDiagClick"/>
+                <MenuItem x:Name="menuHelp" Header="Get _Help Online" HorizontalAlignment="Left" MinWidth="137" Click="MenuHelpClick"/>
+                <MenuItem x:Name="menuDiag" Header="_Diagnostics" HorizontalAlignment="Left" MinWidth="137" Click="MenuDiagClick"/>
                 <MenuItem Header="_Logs">
                     <MenuItem Header="_Current">
                         <MenuItem Header="_Share" Click="MenuShareCurrentLogClick"/>
@@ -53,7 +53,7 @@
                         <MenuItem Header="_Save As..." Click="MenuSaveAsPreviousLogClick"/>
                     </MenuItem>
                 </MenuItem>
-                <MenuItem x:Name="menuAbout" Header="_About" HorizontalAlignment="Left" Width="137" Click="MenuAboutClick"/>
+                <MenuItem x:Name="menuAbout" Header="_About" HorizontalAlignment="Left" MinWidth="137" Click="MenuAboutClick"/>
             </MenuItem>
             <!--<MenuItem x:Name="menuSub"  Header="_Subscribe" Visibility="Collapsed">
                 <MenuItem x:Name="menuSubSubscribe" Header="_Subscribe" Click="MenuSubClick"/>


### PR DESCRIPTION
- fixed buttons and menus that were too small to fit the text (possibly due to my non-standard default Windows font size)
- login tab: fixed username/password heights; fixed width jump when start typing; fixed right align; fixed the visual vertical separator

Screenshots:
- http://i.imgur.com/aFGPvym.png
- http://i.imgur.com/CticLoR.png
- http://i.imgur.com/WWpuRyN.png